### PR TITLE
fix typo in 16.3: derivative of sigmoid function

### DIFF
--- a/notebooks-html/classification_cost.html
+++ b/notebooks-html/classification_cost.html
@@ -217,7 +217,7 @@ $$
 \begin{aligned}
 \sigma(t) &amp;= \frac{1}{1 + e^{-t}} \\
 \sigma'(t) &amp;= \frac{e^{-t}}{(1 + e^{-t})^2} \\
-\sigma'(t) &amp;= \frac{1}{1 + e^{-t}} \cdot \left(1 - \frac{e^{-t}}{1 + e^{-t}} \right) \\
+\sigma'(t) &amp;= \frac{1}{1 + e^{-t}} \cdot \left(1 - \frac{1}{1 + e^{-t}} \right) \\
 \sigma'(t) &amp;= \sigma(t) (1 - \sigma(t))
 \end{aligned}
 $$<p>The derivative of the sigmoid function can be conveniently expressed in terms of the sigmoid function itself.</p></div></div></div>


### PR DESCRIPTION
Fix typo found in 16.3, in the derivative of the sigmoid function.