### PR TITLE
Changed cost to loss and X_i to x_i

### DIFF
--- a/notebooks-html/classification_cost.html
+++ b/notebooks-html/classification_cost.html
@@ -4,7 +4,7 @@
         <button class="interact-button js-nbinteract-widget">
             Show Widgets
         </button>
-        <a class="interact-button" href="http://data100.datahub.berkeley.edu/user-redirect/git-pull?repo=https://github.com/DS-100/textbook&subPath=notebooks/ch16/classification_cost.ipynb">Open on DataHub</a></div>
+        <a class="interact-button" href="http://data100.datahub.berkeley.edu/user-redirect/git-pull?repo=https://github.com/DS-100/textbook&subPath=notebooks/ch17/classification_cost.ipynb">Open on DataHub</a></div>
     
 
 
@@ -23,7 +23,7 @@
 
 <span class="c1"># Set directory for data loading to work properly</span>
 <span class="kn">import</span> <span class="nn">os</span>
-<span class="n">os</span><span class="o">.</span><span class="n">chdir</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">expanduser</span><span class="p">(</span><span class="s1">&#39;~/notebooks/ch16&#39;</span><span class="p">))</span>
+<span class="n">os</span><span class="o">.</span><span class="n">chdir</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">expanduser</span><span class="p">(</span><span class="s1">&#39;~/notebooks/ch17&#39;</span><span class="p">))</span>
 </pre></div></div></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
@@ -89,13 +89,13 @@
 </pre></div></div></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h2 id="A-Cost-Function-for-the-Logistic-Model">A Cost Function for the Logistic Model<a class="anchor-link" href="#A-Cost-Function-for-the-Logistic-Model">&#182;</a></h2><p>We have defined a regression model for probabilities, the logistic model:</p>
+<h2 id="A-Loss-Function-for-the-Logistic-Model">A Loss Function for the Logistic Model<a class="anchor-link" href="#A-Loss-Function-for-the-Logistic-Model">&#182;</a></h2><p>We have defined a regression model for probabilities, the logistic model:</p>
 <p>$$
 \begin{aligned}
 f_\hat{\theta} (x) = \sigma(\hat{\theta} \cdot x)
 \end{aligned}
 $$</p>
-<p>Like the model for linear regression, this model has parameters $ \hat{\theta} $, a vector that contains one parameter for each feature of $ x $. We now address the problem of defining a cost function for this model which allows us to fit the model's parameters to data.</p>
+<p>Like the model for linear regression, this model has parameters $ \hat{\theta} $, a vector that contains one parameter for each feature of $ x $. We now address the problem of defining a loss function for this model which allows us to fit the model's parameters to data.</p>
 <p>Intuitively, we want the model's predictions to match the data as closely as possible. Below we recreate a plot of LeBron's shot attempts in the 2017 NBA Playoffs using the distance of each shot from the basket. The points are jittered on the y-axis to mitigate overplotting.</p></div></div></div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
@@ -173,31 +173,31 @@ $$</p>
 ></div></div></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>Although we can use the mean squared error cost function as we have for linear regression, for a logistic model this cost function is non-convex and thus difficult to optimize.</p></div></div></div>
+<p>Although we can use the mean squared error loss function as we have for linear regression, for a logistic model this loss function is non-convex and thus difficult to optimize.</p></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h2 id="The-Cross-Entropy-Cost">The Cross Entropy Cost<a class="anchor-link" href="#The-Cross-Entropy-Cost">&#182;</a></h2><p>Instead of the mean squared error, we use the <strong>cross entropy cost</strong>. Let $ X $ represent the $ n \times p $ input data matrix, $ y $ the vector of observed data values, and $ f_\hat{\theta}(x) $ the logistic model. Using this notation, the cross entropy cost is defined as:</p>
+<h2 id="The-Cross-Entropy-Loss">The Cross-Entropy Loss<a class="anchor-link" href="#The-Cross-Entropy-Loss">&#182;</a></h2><p>Instead of the mean squared error, we use the <strong>cross-entropy loss</strong>. Let $ X $ represent the $ n \times p $ input data matrix, $ y $ the vector of observed data values, and $ f_\hat{\theta}(x) $ the logistic model evaluated at $x$, a row vector from $X$. Using this notation, the cross-entropy loss is defined as:</p>
 <p>$$
 \begin{aligned}
-L(\hat{\theta}, X, y) = \frac{1}{n} \sum_i \left(- y_i \ln (f_\hat{\theta}(X_i)) - (1 - y_i) \ln (1 - f_\hat{\theta}(X_i) \right)
+L(\hat{\theta}, X, y) = \frac{1}{n} \sum_i \left(- y_i \ln (f_\hat{\theta}(x_i)) - (1 - y_i) \ln (1 - f_\hat{\theta}(x_i) \right)
 \end{aligned}
 $$</p></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>You may observe that as usual we take the mean loss over each point in our dataset. This loss is called the cross entropy loss and forms the inner expression in the above summation:</p>
+<p>You may observe that as usual we take the mean loss over each point $(x_i, y_i)$ in our dataset. This loss is called the cross-entropy loss and forms the inner expression in the above summation:</p>
 <p>$$
 \begin{aligned}
-\ell(\hat{\theta}, X, y) = - y_i \ln (f_\hat{\theta}(X_i)) - (1 - y_i) \ln (1 - f_\hat{\theta}(X_i) )
+\ell(\hat{\theta}, x_i, y_i) = - y_i \ln (f_\hat{\theta}(x_i)) - (1 - y_i) \ln (1 - f_\hat{\theta}(x_i) )
 \end{aligned}
 $$</p></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>Recall that each $ y_i $ is either 0 or 1 in our dataset. If $ y_i = 0 $, the first term in the loss is zero. If $ y_i = 1 $, the second term in the loss is zero. Thus, only one term of the cross entropy loss contributes to the overall cost for each point in our dataset.</p>
-<p>Suppose $ y_i = 0 $ and our predicted probability $ f_\hat{\theta}(X_i) = 0 $—our model is completely correct. The loss for this point will be:</p>
+<p>Recall that each $ y_i $ is either 0 or 1 in our dataset. If $ y_i = 0 $, the first term in the loss is zero. If $ y_i = 1 $, the second term in the loss is zero. Thus, only one term of the cross-entropy loss contributes to the overall cost for each point in our dataset.</p>
+<p>Suppose $ y_i = 0 $ and our predicted probability $ f_\hat{\theta}(x_i) = 0 $—our model is completely correct. The loss for this point is:</p>
 <p>$$
 \begin{aligned}
-\ell(\hat{\theta}, X, y)
-&amp;= - y_i \ln (f_\hat{\theta}(X_i)) - (1 - y_i) \ln (1 - f_\hat{\theta}(X_i) ) \\
+\ell(\hat{\theta}, x_i, y_i)
+&amp;= - y_i \ln (f_\hat{\theta}(x_i)) - (1 - y_i) \ln (1 - f_\hat{\theta}(x_i) ) \\
 &amp;= - 0 - (1 - 0) \ln (1 - 0 ) \\
 &amp;= - \ln (1) \\
 &amp;= 0
@@ -206,10 +206,10 @@ $$</p></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>As expected, the loss for a correct prediction is $ 0 $. You may verify that the further the predicted probability is from the true value, the greater the loss.</p>
-<p>Minimizing the overall cross entropy cost requires the model $ f_\hat{\theta}(x) $ to make the most accurate predictions it can. Conveniently, this cost function is convex, making gradient descent a useful choice for optimization.</p></div></div></div>
+<p>Minimizing the overall cross-entropy loss requires the model $ f_\hat{\theta}(x) $ to make the most accurate predictions it can. Conveniently, this loss function is convex, making gradient descent a useful choice for optimization.</p></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h2 id="Gradient-of-the-Cross-Entropy-Cost">Gradient of the Cross Entropy Cost<a class="anchor-link" href="#Gradient-of-the-Cross-Entropy-Cost">&#182;</a></h2><p>In order to run gradient descent on the cross entropy cost we must calculate the gradient of the cost function. First, we compute the derivative of the sigmoid function since we'll use it in our gradient calculation.</p>
+<h2 id="Gradient-of-the-Cross-Entropy-Loss">Gradient of the Cross-Entropy Loss<a class="anchor-link" href="#Gradient-of-the-Cross-Entropy-Loss">&#182;</a></h2><p>In order to run gradient descent on the cross-entropy loss we must calculate the gradient of the loss function. First, we compute the derivative of the sigmoid function since we'll use it in our gradient calculation.</p>
 <p>$$
 \begin{aligned}
 \sigma(t) &amp;= \frac{1}{1 + e^{-t}} \\
@@ -221,22 +221,22 @@ $$</p>
 <p>The derivative of the sigmoid function can be conveniently expressed in terms of the sigmoid function itself.</p></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>As a shorthand, we define $ \sigma_i = f_\hat{\theta}(X_i) = \sigma(X_i \cdot \hat \theta) $. We will soon need the gradient of $ \sigma_i $ with respect to the vector $ \hat{\theta} $ so we will derive it now using a straightforward application of the chain rule.</p>
+<p>As a shorthand, we define $ \sigma_i = f_\hat{\theta}(x_i) = \sigma(x_i \cdot \hat \theta) $. We will soon need the gradient of $ \sigma_i $ with respect to the vector $ \hat{\theta} $ so we will derive it now using a straightforward application of the chain rule.</p>
 <p>$$
 \begin{aligned}
 \nabla_{\hat{\theta}} \sigma_i
-&amp;= \nabla_{\hat{\theta}} \sigma(X_i \cdot \hat \theta) \\
-&amp;= \sigma(X_i \cdot \hat \theta) (1 - \sigma(X_i \cdot \hat \theta))  \nabla_{\hat{\theta}} (X_i \cdot \hat \theta) \\
-&amp;= \sigma_i (1 - \sigma_i) X_i 
+&amp;= \nabla_{\hat{\theta}} \sigma(x_i \cdot \hat \theta) \\
+&amp;= \sigma(x_i \cdot \hat \theta) (1 - \sigma(x_i \cdot \hat \theta))  \nabla_{\hat{\theta}} (x_i \cdot \hat \theta) \\
+&amp;= \sigma_i (1 - \sigma_i) x_i 
 \end{aligned}
 $$</p></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>Now, we derive the gradient for the cross entropy cost with respect to the model parameters $ \hat{\theta} $. In the derivation below, we let $ \sigma_i = f_\hat{\theta}(X_i) = \sigma(X_i \cdot \hat \theta) $.</p>
+<p>Now, we derive the gradient for the cross-entropy loss with respect to the model parameters $ \hat{\theta} $. In the derivation below, we let $ \sigma_i = f_\hat{\theta}(x_i) = \sigma(x_i \cdot \hat \theta) $.</p>
 <p>$$
 \begin{aligned}
 L(\hat{\theta}, X, y)
-&amp;= \frac{1}{n} \sum_i \left(- y<em>i \ln (f</em>\hat{\theta}(X_i)) - (1 - y<em>i) \ln (1 - f</em>\hat{\theta}(X_i) \right) \
+&amp;= \frac{1}{n} \sum_i \left(- y<em>i \ln (f</em>\hat{\theta}(x_i)) - (1 - y<em>i) \ln (1 - f</em>\hat{\theta}(x_i) \right) \
 &amp;= \frac{1}{n} \sum_i \left(- y_i \ln \sigma_i - (1 - y_i) \ln (1 - \sigma<em>i ) \right) \
 \nabla</em>{\hat{\theta}} L(\hat{\theta}, X, y)
 &amp;= \frac{1}{n} \sum_i \left(</p>
@@ -250,15 +250,15 @@ L(\hat{\theta}, X, y)
 \right) \nabla</em>{\hat{\theta}} \sigma_i \
 &amp;= - \frac{1}{n} \sum_i \left(
     \frac{y_i}{\sigma_i} - \frac{1 - y_i}{1 - \sigma_i}
-\right) \sigma_i (1 - \sigma_i) X_i \
+\right) \sigma_i (1 - \sigma_i) x_i \
 &amp;= - \frac{1}{n} \sum_i \left(
     y_i - \sigma_i
-\right) X_i \
+\right) x_i \
 \end{aligned}
 $$</p></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>The surprisingly simple gradient expression allows us to fit a logistic model to the cross entropy loss using gradient descent.</p></div></div></div>
+<p>The surprisingly simple gradient expression allows us to fit a logistic model to the cross-entropy loss using gradient descent.</p></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h2 id="Summary">Summary<a class="anchor-link" href="#Summary">&#182;</a></h2><p>Since the cross-entropy loss function is convex, we minimize this loss using gradient descent to fit logistic models to data. We now have the necessary components of logistic regression: the model, cost function, and minimization procedure.</p></div></div></div></div>
+<h2 id="Summary">Summary<a class="anchor-link" href="#Summary">&#182;</a></h2><p>Since the cross-entropy loss function is convex, we minimize this loss using gradient descent to fit logistic models to data. We now have the necessary components of logistic regression: the model, loss function, and minimization procedure.</p></div></div></div></div>

--- a/notebooks-html/classification_cost_justification.html
+++ b/notebooks-html/classification_cost_justification.html
@@ -4,7 +4,7 @@
         <button class="interact-button js-nbinteract-widget">
             Show Widgets
         </button>
-        <a class="interact-button" href="http://data100.datahub.berkeley.edu/user-redirect/git-pull?repo=https://github.com/DS-100/textbook&subPath=notebooks/ch16/classification_cost_justification.ipynb">Open on DataHub</a></div>
+        <a class="interact-button" href="http://data100.datahub.berkeley.edu/user-redirect/git-pull?repo=https://github.com/DS-100/textbook&subPath=notebooks/ch17/classification_cost_justification.ipynb">Open on DataHub</a></div>
     
 
 
@@ -23,7 +23,7 @@
 
 <span class="c1"># Set directory for data loading to work properly</span>
 <span class="kn">import</span> <span class="nn">os</span>
-<span class="n">os</span><span class="o">.</span><span class="n">chdir</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">expanduser</span><span class="p">(</span><span class="s1">&#39;~/notebooks/ch16&#39;</span><span class="p">))</span>
+<span class="n">os</span><span class="o">.</span><span class="n">chdir</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">expanduser</span><span class="p">(</span><span class="s1">&#39;~/notebooks/ch17&#39;</span><span class="p">))</span>
 </pre></div></div></div></div></div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">

--- a/notebooks-html/classification_log_model.html
+++ b/notebooks-html/classification_log_model.html
@@ -4,7 +4,7 @@
         <button class="interact-button js-nbinteract-widget">
             Show Widgets
         </button>
-        <a class="interact-button" href="http://data100.datahub.berkeley.edu/user-redirect/git-pull?repo=https://github.com/DS-100/textbook&subPath=notebooks/ch16/classification_log_model.ipynb">Open on DataHub</a></div>
+        <a class="interact-button" href="http://data100.datahub.berkeley.edu/user-redirect/git-pull?repo=https://github.com/DS-100/textbook&subPath=notebooks/ch17/classification_log_model.ipynb">Open on DataHub</a></div>
     
 
 
@@ -23,7 +23,7 @@
 
 <span class="c1"># Set directory for data loading to work properly</span>
 <span class="kn">import</span> <span class="nn">os</span>
-<span class="n">os</span><span class="o">.</span><span class="n">chdir</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">expanduser</span><span class="p">(</span><span class="s1">&#39;~/notebooks/ch16&#39;</span><span class="p">))</span>
+<span class="n">os</span><span class="o">.</span><span class="n">chdir</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">expanduser</span><span class="p">(</span><span class="s1">&#39;~/notebooks/ch17&#39;</span><span class="p">))</span>
 </pre></div></div></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">

--- a/notebooks-html/classification_log_reg.html
+++ b/notebooks-html/classification_log_reg.html
@@ -4,7 +4,7 @@
         <button class="interact-button js-nbinteract-widget">
             Show Widgets
         </button>
-        <a class="interact-button" href="http://data100.datahub.berkeley.edu/user-redirect/git-pull?repo=https://github.com/DS-100/textbook&subPath=notebooks/ch16/classification_log_reg.ipynb">Open on DataHub</a></div>
+        <a class="interact-button" href="http://data100.datahub.berkeley.edu/user-redirect/git-pull?repo=https://github.com/DS-100/textbook&subPath=notebooks/ch17/classification_log_reg.ipynb">Open on DataHub</a></div>
     
 
 
@@ -23,7 +23,7 @@
 
 <span class="c1"># Set directory for data loading to work properly</span>
 <span class="kn">import</span> <span class="nn">os</span>
-<span class="n">os</span><span class="o">.</span><span class="n">chdir</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">expanduser</span><span class="p">(</span><span class="s1">&#39;~/notebooks/ch16&#39;</span><span class="p">))</span>
+<span class="n">os</span><span class="o">.</span><span class="n">chdir</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">expanduser</span><span class="p">(</span><span class="s1">&#39;~/notebooks/ch17&#39;</span><span class="p">))</span>
 </pre></div></div></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">

--- a/notebooks-html/classification_prob.html
+++ b/notebooks-html/classification_prob.html
@@ -4,7 +4,7 @@
         <button class="interact-button js-nbinteract-widget">
             Show Widgets
         </button>
-        <a class="interact-button" href="http://data100.datahub.berkeley.edu/user-redirect/git-pull?repo=https://github.com/DS-100/textbook&subPath=notebooks/ch16/classification_prob.ipynb">Open on DataHub</a></div>
+        <a class="interact-button" href="http://data100.datahub.berkeley.edu/user-redirect/git-pull?repo=https://github.com/DS-100/textbook&subPath=notebooks/ch17/classification_prob.ipynb">Open on DataHub</a></div>
     
 
 
@@ -23,7 +23,7 @@
 
 <span class="c1"># Set directory for data loading to work properly</span>
 <span class="kn">import</span> <span class="nn">os</span>
-<span class="n">os</span><span class="o">.</span><span class="n">chdir</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">expanduser</span><span class="p">(</span><span class="s1">&#39;~/notebooks/ch16&#39;</span><span class="p">))</span>
+<span class="n">os</span><span class="o">.</span><span class="n">chdir</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">expanduser</span><span class="p">(</span><span class="s1">&#39;~/notebooks/ch17&#39;</span><span class="p">))</span>
 </pre></div></div></div></div></div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">

--- a/notebooks/ch17/classification_cost.ipynb
+++ b/notebooks/ch17/classification_cost.ipynb
@@ -72,7 +72,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## A Cost Function for the Logistic Model\n",
+    "## A Loss Function for the Logistic Model\n",
     "\n",
     "We have defined a regression model for probabilities, the logistic model:\n",
     "\n",
@@ -82,7 +82,7 @@
     "\\end{aligned}\n",
     "$$\n",
     "\n",
-    "Like the model for linear regression, this model has parameters $ \\hat{\\theta} $, a vector that contains one parameter for each feature of $ x $. We now address the problem of defining a cost function for this model which allows us to fit the model's parameters to data.\n",
+    "Like the model for linear regression, this model has parameters $ \\hat{\\theta} $, a vector that contains one parameter for each feature of $ x $. We now address the problem of defining a loss function for this model which allows us to fit the model's parameters to data.\n",
     "\n",
     "Intuitively, we want the model's predictions to match the data as closely as possible. Below we recreate a plot of LeBron's shot attempts in the 2017 NBA Playoffs using the distance of each shot from the basket. The points are jittered on the y-axis to mitigate overplotting."
    ]
@@ -163,20 +163,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Although we can use the mean squared error cost function as we have for linear regression, for a logistic model this cost function is non-convex and thus difficult to optimize."
+    "Although we can use the mean squared error loss function as we have for linear regression, for a logistic model this loss function is non-convex and thus difficult to optimize."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## The Cross Entropy Cost\n",
+    "## The Cross-Entropy Loss\n",
     "\n",
-    "Instead of the mean squared error, we use the **cross entropy cost**. Let $ X $ represent the $ n \\times p $ input data matrix, $ y $ the vector of observed data values, and $ f_\\hat{\\theta}(x) $ the logistic model. Using this notation, the cross entropy cost is defined as:\n",
+    "Instead of the mean squared error, we use the **cross-entropy loss**. Let $ X $ represent the $ n \\times p $ input data matrix, $ y $ the vector of observed data values, and $ f_\\hat{\\theta}(x) $ the logistic model evaluated at $x$, a row vector from $X$. Using this notation, the cross-entropy loss is defined as:\n",
     "\n",
     "$$\n",
     "\\begin{aligned}\n",
-    "L(\\hat{\\theta}, X, y) = \\frac{1}{n} \\sum_i \\left(- y_i \\ln (f_\\hat{\\theta}(X_i)) - (1 - y_i) \\ln (1 - f_\\hat{\\theta}(X_i) \\right)\n",
+    "L(\\hat{\\theta}, X, y) = \\frac{1}{n} \\sum_i \\left(- y_i \\ln (f_\\hat{\\theta}(x_i)) - (1 - y_i) \\ln (1 - f_\\hat{\\theta}(x_i) \\right)\n",
     "\\end{aligned}\n",
     "$$"
    ]
@@ -185,11 +185,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You may observe that as usual we take the mean loss over each point in our dataset. This loss is called the cross entropy loss and forms the inner expression in the above summation: \n",
+    "You may observe that as usual we take the mean loss over each point $(x_i, y_i)$ in our dataset. This loss is called the cross-entropy loss and forms the inner expression in the above summation: \n",
     "\n",
     "$$\n",
     "\\begin{aligned}\n",
-    "\\ell(\\hat{\\theta}, X, y) = - y_i \\ln (f_\\hat{\\theta}(X_i)) - (1 - y_i) \\ln (1 - f_\\hat{\\theta}(X_i) )\n",
+    "\\ell(\\hat{\\theta}, x_i, y_i) = - y_i \\ln (f_\\hat{\\theta}(x_i)) - (1 - y_i) \\ln (1 - f_\\hat{\\theta}(x_i) )\n",
     "\\end{aligned}\n",
     "$$"
    ]
@@ -198,14 +198,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Recall that each $ y_i $ is either 0 or 1 in our dataset. If $ y_i = 0 $, the first term in the loss is zero. If $ y_i = 1 $, the second term in the loss is zero. Thus, only one term of the cross entropy loss contributes to the overall cost for each point in our dataset.\n",
+    "Recall that each $ y_i $ is either 0 or 1 in our dataset. If $ y_i = 0 $, the first term in the loss is zero. If $ y_i = 1 $, the second term in the loss is zero. Thus, only one term of the cross-entropy loss contributes to the overall cost for each point in our dataset.\n",
     "\n",
-    "Suppose $ y_i = 0 $ and our predicted probability $ f_\\hat{\\theta}(X_i) = 0 $—our model is completely correct. The loss for this point will be:\n",
+    "Suppose $ y_i = 0 $ and our predicted probability $ f_\\hat{\\theta}(x_i) = 0 $—our model is completely correct. The loss for this point is:\n",
     "\n",
     "$$\n",
     "\\begin{aligned}\n",
-    "\\ell(\\hat{\\theta}, X, y)\n",
-    "&= - y_i \\ln (f_\\hat{\\theta}(X_i)) - (1 - y_i) \\ln (1 - f_\\hat{\\theta}(X_i) ) \\\\\n",
+    "\\ell(\\hat{\\theta}, x_i, y_i)\n",
+    "&= - y_i \\ln (f_\\hat{\\theta}(x_i)) - (1 - y_i) \\ln (1 - f_\\hat{\\theta}(x_i) ) \\\\\n",
     "&= - 0 - (1 - 0) \\ln (1 - 0 ) \\\\\n",
     "&= - \\ln (1) \\\\\n",
     "&= 0\n",
@@ -219,16 +219,16 @@
    "source": [
     "As expected, the loss for a correct prediction is $ 0 $. You may verify that the further the predicted probability is from the true value, the greater the loss.\n",
     "\n",
-    "Minimizing the overall cross entropy cost requires the model $ f_\\hat{\\theta}(x) $ to make the most accurate predictions it can. Conveniently, this cost function is convex, making gradient descent a useful choice for optimization."
+    "Minimizing the overall cross-entropy loss requires the model $ f_\\hat{\\theta}(x) $ to make the most accurate predictions it can. Conveniently, this loss function is convex, making gradient descent a useful choice for optimization."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Gradient of the Cross Entropy Cost\n",
+    "## Gradient of the Cross-Entropy Loss\n",
     "\n",
-    "In order to run gradient descent on the cross entropy cost we must calculate the gradient of the cost function. First, we compute the derivative of the sigmoid function since we'll use it in our gradient calculation.\n",
+    "In order to run gradient descent on the cross-entropy loss we must calculate the gradient of the loss function. First, we compute the derivative of the sigmoid function since we'll use it in our gradient calculation.\n",
     "\n",
     "$$\n",
     "\\begin{aligned}\n",
@@ -246,14 +246,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As a shorthand, we define $ \\sigma_i = f_\\hat{\\theta}(X_i) = \\sigma(X_i \\cdot \\hat \\theta) $. We will soon need the gradient of $ \\sigma_i $ with respect to the vector $ \\hat{\\theta} $ so we will derive it now using a straightforward application of the chain rule. \n",
+    "As a shorthand, we define $ \\sigma_i = f_\\hat{\\theta}(x_i) = \\sigma(x_i \\cdot \\hat \\theta) $. We will soon need the gradient of $ \\sigma_i $ with respect to the vector $ \\hat{\\theta} $ so we will derive it now using a straightforward application of the chain rule. \n",
     "\n",
     "$$\n",
     "\\begin{aligned}\n",
     "\\nabla_{\\hat{\\theta}} \\sigma_i\n",
-    "&= \\nabla_{\\hat{\\theta}} \\sigma(X_i \\cdot \\hat \\theta) \\\\\n",
-    "&= \\sigma(X_i \\cdot \\hat \\theta) (1 - \\sigma(X_i \\cdot \\hat \\theta))  \\nabla_{\\hat{\\theta}} (X_i \\cdot \\hat \\theta) \\\\\n",
-    "&= \\sigma_i (1 - \\sigma_i) X_i \n",
+    "&= \\nabla_{\\hat{\\theta}} \\sigma(x_i \\cdot \\hat \\theta) \\\\\n",
+    "&= \\sigma(x_i \\cdot \\hat \\theta) (1 - \\sigma(x_i \\cdot \\hat \\theta))  \\nabla_{\\hat{\\theta}} (x_i \\cdot \\hat \\theta) \\\\\n",
+    "&= \\sigma_i (1 - \\sigma_i) x_i \n",
     "\\end{aligned}\n",
     "$$"
    ]
@@ -262,12 +262,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, we derive the gradient for the cross entropy cost with respect to the model parameters $ \\hat{\\theta} $. In the derivation below, we let $ \\sigma_i = f_\\hat{\\theta}(X_i) = \\sigma(X_i \\cdot \\hat \\theta) $.\n",
+    "Now, we derive the gradient for the cross-entropy loss with respect to the model parameters $ \\hat{\\theta} $. In the derivation below, we let $ \\sigma_i = f_\\hat{\\theta}(x_i) = \\sigma(x_i \\cdot \\hat \\theta) $.\n",
     "\n",
     "$$\n",
     "\\begin{aligned}\n",
     "L(\\hat{\\theta}, X, y)\n",
-    "&= \\frac{1}{n} \\sum_i \\left(- y_i \\ln (f_\\hat{\\theta}(X_i)) - (1 - y_i) \\ln (1 - f_\\hat{\\theta}(X_i) \\right) \\\\\n",
+    "&= \\frac{1}{n} \\sum_i \\left(- y_i \\ln (f_\\hat{\\theta}(x_i)) - (1 - y_i) \\ln (1 - f_\\hat{\\theta}(x_i) \\right) \\\\\n",
     "&= \\frac{1}{n} \\sum_i \\left(- y_i \\ln \\sigma_i - (1 - y_i) \\ln (1 - \\sigma_i ) \\right) \\\\\n",
     "\\nabla_{\\hat{\\theta}} L(\\hat{\\theta}, X, y)\n",
     "&= \\frac{1}{n} \\sum_i \\left(\n",
@@ -279,10 +279,10 @@
     "\\right) \\nabla_{\\hat{\\theta}} \\sigma_i \\\\\n",
     "&= - \\frac{1}{n} \\sum_i \\left(\n",
     "    \\frac{y_i}{\\sigma_i} - \\frac{1 - y_i}{1 - \\sigma_i}\n",
-    "\\right) \\sigma_i (1 - \\sigma_i) X_i \\\\\n",
+    "\\right) \\sigma_i (1 - \\sigma_i) x_i \\\\\n",
     "&= - \\frac{1}{n} \\sum_i \\left(\n",
     "    y_i - \\sigma_i\n",
-    "\\right) X_i \\\\\n",
+    "\\right) x_i \\\\\n",
     "\\end{aligned}\n",
     "$$"
    ]
@@ -291,7 +291,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The surprisingly simple gradient expression allows us to fit a logistic model to the cross entropy loss using gradient descent."
+    "The surprisingly simple gradient expression allows us to fit a logistic model to the cross-entropy loss using gradient descent."
    ]
   },
   {
@@ -300,7 +300,7 @@
    "source": [
     "## Summary\n",
     "\n",
-    "Since the cross-entropy loss function is convex, we minimize this loss using gradient descent to fit logistic models to data. We now have the necessary components of logistic regression: the model, cost function, and minimization procedure."
+    "Since the cross-entropy loss function is convex, we minimize this loss using gradient descent to fit logistic models to data. We now have the necessary components of logistic regression: the model, loss function, and minimization procedure."
    ]
   }
  ],

--- a/notebooks/ch17/classification_cost.md
+++ b/notebooks/ch17/classification_cost.md
@@ -48,7 +48,7 @@ def df_interact(df, nrows=7, ncols=7):
 lebron = pd.read_csv('lebron.csv')
 ```
 
-## A Cost Function for the Logistic Model
+## A Loss Function for the Logistic Model
 
 We have defined a regression model for probabilities, the logistic model:
 
@@ -58,7 +58,7 @@ f_\hat{\theta} (x) = \sigma(\hat{\theta} \cdot x)
 \end{aligned}
 $$
 
-Like the model for linear regression, this model has parameters $ \hat{\theta} $, a vector that contains one parameter for each feature of $ x $. We now address the problem of defining a cost function for this model which allows us to fit the model's parameters to data.
+Like the model for linear regression, this model has parameters $ \hat{\theta} $, a vector that contains one parameter for each feature of $ x $. We now address the problem of defining a loss function for this model which allows us to fit the model's parameters to data.
 
 Intuitively, we want the model's predictions to match the data as closely as possible. Below we recreate a plot of LeBron's shot attempts in the 2017 NBA Playoffs using the distance of each shot from the basket. The points are jittered on the y-axis to mitigate overplotting.
 
@@ -107,34 +107,34 @@ plt.ylabel('Shot Made');
 ![png](classification_cost_files/classification_cost_7_0.png)
 
 
-Although we can use the mean squared error cost function as we have for linear regression, for a logistic model this cost function is non-convex and thus difficult to optimize.
+Although we can use the mean squared error loss function as we have for linear regression, for a logistic model this loss function is non-convex and thus difficult to optimize.
 
-## The Cross Entropy Cost
+## The Cross-Entropy Loss
 
-Instead of the mean squared error, we use the **cross entropy cost**. Let $ X $ represent the $ n \times p $ input data matrix, $ y $ the vector of observed data values, and $ f_\hat{\theta}(x) $ the logistic model. Using this notation, the cross entropy cost is defined as:
+Instead of the mean squared error, we use the **cross-entropy loss**. Let $ X $ represent the $ n \times p $ input data matrix, $ y $ the vector of observed data values, and $ f_\hat{\theta}(x) $ the logistic model evaluated at $x$, a row vector from $X$. Using this notation, the cross-entropy loss is defined as:
 
 $$
 \begin{aligned}
-L(\hat{\theta}, X, y) = \frac{1}{n} \sum_i \left(- y_i \ln (f_\hat{\theta}(X_i)) - (1 - y_i) \ln (1 - f_\hat{\theta}(X_i) \right)
+L(\hat{\theta}, X, y) = \frac{1}{n} \sum_i \left(- y_i \ln (f_\hat{\theta}(x_i)) - (1 - y_i) \ln (1 - f_\hat{\theta}(x_i) \right)
 \end{aligned}
 $$
 
-You may observe that as usual we take the mean loss over each point in our dataset. This loss is called the cross entropy loss and forms the inner expression in the above summation: 
+You may observe that as usual we take the mean loss over each point $(x_i, y_i)$ in our dataset. This loss is called the cross-entropy loss and forms the inner expression in the above summation: 
 
 $$
 \begin{aligned}
-\ell(\hat{\theta}, X, y) = - y_i \ln (f_\hat{\theta}(X_i)) - (1 - y_i) \ln (1 - f_\hat{\theta}(X_i) )
+\ell(\hat{\theta}, x_i, y_i) = - y_i \ln (f_\hat{\theta}(x_i)) - (1 - y_i) \ln (1 - f_\hat{\theta}(x_i) )
 \end{aligned}
 $$
 
-Recall that each $ y_i $ is either 0 or 1 in our dataset. If $ y_i = 0 $, the first term in the loss is zero. If $ y_i = 1 $, the second term in the loss is zero. Thus, only one term of the cross entropy loss contributes to the overall cost for each point in our dataset.
+Recall that each $ y_i $ is either 0 or 1 in our dataset. If $ y_i = 0 $, the first term in the loss is zero. If $ y_i = 1 $, the second term in the loss is zero. Thus, only one term of the cross-entropy loss contributes to the overall cost for each point in our dataset.
 
-Suppose $ y_i = 0 $ and our predicted probability $ f_\hat{\theta}(X_i) = 0 $—our model is completely correct. The loss for this point will be:
+Suppose $ y_i = 0 $ and our predicted probability $ f_\hat{\theta}(x_i) = 0 $—our model is completely correct. The loss for this point is:
 
 $$
 \begin{aligned}
-\ell(\hat{\theta}, X, y)
-&= - y_i \ln (f_\hat{\theta}(X_i)) - (1 - y_i) \ln (1 - f_\hat{\theta}(X_i) ) \\
+\ell(\hat{\theta}, x_i, y_i)
+&= - y_i \ln (f_\hat{\theta}(x_i)) - (1 - y_i) \ln (1 - f_\hat{\theta}(x_i) ) \\
 &= - 0 - (1 - 0) \ln (1 - 0 ) \\
 &= - \ln (1) \\
 &= 0
@@ -143,11 +143,11 @@ $$
 
 As expected, the loss for a correct prediction is $ 0 $. You may verify that the further the predicted probability is from the true value, the greater the loss.
 
-Minimizing the overall cross entropy cost requires the model $ f_\hat{\theta}(x) $ to make the most accurate predictions it can. Conveniently, this cost function is convex, making gradient descent a useful choice for optimization.
+Minimizing the overall cross-entropy loss requires the model $ f_\hat{\theta}(x) $ to make the most accurate predictions it can. Conveniently, this loss function is convex, making gradient descent a useful choice for optimization.
 
-## Gradient of the Cross Entropy Cost
+## Gradient of the Cross-Entropy Loss
 
-In order to run gradient descent on the cross entropy cost we must calculate the gradient of the cost function. First, we compute the derivative of the sigmoid function since we'll use it in our gradient calculation.
+In order to run gradient descent on the cross-entropy loss we must calculate the gradient of the loss function. First, we compute the derivative of the sigmoid function since we'll use it in our gradient calculation.
 
 $$
 \begin{aligned}
@@ -160,23 +160,23 @@ $$
 
 The derivative of the sigmoid function can be conveniently expressed in terms of the sigmoid function itself.
 
-As a shorthand, we define $ \sigma_i = f_\hat{\theta}(X_i) = \sigma(X_i \cdot \hat \theta) $. We will soon need the gradient of $ \sigma_i $ with respect to the vector $ \hat{\theta} $ so we will derive it now using a straightforward application of the chain rule. 
+As a shorthand, we define $ \sigma_i = f_\hat{\theta}(x_i) = \sigma(x_i \cdot \hat \theta) $. We will soon need the gradient of $ \sigma_i $ with respect to the vector $ \hat{\theta} $ so we will derive it now using a straightforward application of the chain rule. 
 
 $$
 \begin{aligned}
 \nabla_{\hat{\theta}} \sigma_i
-&= \nabla_{\hat{\theta}} \sigma(X_i \cdot \hat \theta) \\
-&= \sigma(X_i \cdot \hat \theta) (1 - \sigma(X_i \cdot \hat \theta))  \nabla_{\hat{\theta}} (X_i \cdot \hat \theta) \\
-&= \sigma_i (1 - \sigma_i) X_i 
+&= \nabla_{\hat{\theta}} \sigma(x_i \cdot \hat \theta) \\
+&= \sigma(x_i \cdot \hat \theta) (1 - \sigma(x_i \cdot \hat \theta))  \nabla_{\hat{\theta}} (x_i \cdot \hat \theta) \\
+&= \sigma_i (1 - \sigma_i) x_i 
 \end{aligned}
 $$
 
-Now, we derive the gradient for the cross entropy cost with respect to the model parameters $ \hat{\theta} $. In the derivation below, we let $ \sigma_i = f_\hat{\theta}(X_i) = \sigma(X_i \cdot \hat \theta) $.
+Now, we derive the gradient for the cross-entropy loss with respect to the model parameters $ \hat{\theta} $. In the derivation below, we let $ \sigma_i = f_\hat{\theta}(x_i) = \sigma(x_i \cdot \hat \theta) $.
 
 $$
 \begin{aligned}
 L(\hat{\theta}, X, y)
-&= \frac{1}{n} \sum_i \left(- y_i \ln (f_\hat{\theta}(X_i)) - (1 - y_i) \ln (1 - f_\hat{\theta}(X_i) \right) \\
+&= \frac{1}{n} \sum_i \left(- y_i \ln (f_\hat{\theta}(x_i)) - (1 - y_i) \ln (1 - f_\hat{\theta}(x_i) \right) \\
 &= \frac{1}{n} \sum_i \left(- y_i \ln \sigma_i - (1 - y_i) \ln (1 - \sigma_i ) \right) \\
 \nabla_{\hat{\theta}} L(\hat{\theta}, X, y)
 &= \frac{1}{n} \sum_i \left(
@@ -188,15 +188,15 @@ L(\hat{\theta}, X, y)
 \right) \nabla_{\hat{\theta}} \sigma_i \\
 &= - \frac{1}{n} \sum_i \left(
     \frac{y_i}{\sigma_i} - \frac{1 - y_i}{1 - \sigma_i}
-\right) \sigma_i (1 - \sigma_i) X_i \\
+\right) \sigma_i (1 - \sigma_i) x_i \\
 &= - \frac{1}{n} \sum_i \left(
     y_i - \sigma_i
-\right) X_i \\
+\right) x_i \\
 \end{aligned}
 $$
 
-The surprisingly simple gradient expression allows us to fit a logistic model to the cross entropy loss using gradient descent.
+The surprisingly simple gradient expression allows us to fit a logistic model to the cross-entropy loss using gradient descent.
 
 ## Summary
 
-Since the cross-entropy loss function is convex, we minimize this loss using gradient descent to fit logistic models to data. We now have the necessary components of logistic regression: the model, cost function, and minimization procedure.
+Since the cross-entropy loss function is convex, we minimize this loss using gradient descent to fit logistic models to data. We now have the necessary components of logistic regression: the model, loss function, and minimization procedure.


### PR DESCRIPTION
I renamed all "cost" mentions to "loss". Also, instead of using X_i to refer to a row of the data matrix X, I thought it would be clearer to readers to use x_i since this matches the lowercase format of the corresponding label y. Let me know if this doesn't make sense; I can convert them back to X_i.