### PR TITLE
Fix code for text cleaning example

### DIFF
--- a/ch/08/text_strings.html
+++ b/ch/08/text_strings.html
@@ -363,7 +363,7 @@ next_page: '/ch/08/text_regex.html'
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">john1</span> <span class="o">=</span> <span class="n">state</span><span class="o">.</span><span class="n">loc</span><span class="p">[</span><span class="mi">3</span><span class="p">,</span> <span class="s1">&#39;County&#39;</span><span class="p">]</span>
-<span class="n">john2</span> <span class="o">=</span> <span class="n">population</span><span class="o">.</span><span class="n">loc</span><span class="p">[</span><span class="mi">0</span><span class="p">,</span> <span class="s1">&#39;County&#39;</span><span class="p">]</span>
+<span class="n">john2</span> <span class="o">=</span> <span class="n">population</span><span class="o">.</span><span class="n">loc</span><span class="p">[</span><span class="mi">3</span><span class="p">,</span> <span class="s1">&#39;County&#39;</span><span class="p">]</span>
 
 <span class="p">(</span><span class="n">john1</span>
  <span class="o">.</span><span class="n">lower</span><span class="p">()</span>
@@ -416,7 +416,7 @@ next_page: '/ch/08/text_regex.html'
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="p">(</span><span class="n">john1</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="p">(</span><span class="n">john2</span>
  <span class="o">.</span><span class="n">lower</span><span class="p">()</span>
  <span class="o">.</span><span class="n">strip</span><span class="p">()</span>
  <span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="s1">&#39; parish&#39;</span><span class="p">,</span> <span class="s1">&#39;&#39;</span><span class="p">)</span>

--- a/notebooks/08/text_strings.ipynb
+++ b/notebooks/08/text_strings.ipynb
@@ -2,8 +2,12 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 10,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-09-23T22:51:54.881467Z",
+     "start_time": "2018-09-23T22:51:54.874876Z"
+    },
     "colab": {
      "autoexec": {
       "startup": false,
@@ -54,8 +58,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 2,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-09-23T22:51:18.845087Z",
+     "start_time": "2018-09-23T22:51:18.837527Z"
+    },
     "colab": {
      "autoexec": {
       "startup": false,
@@ -100,8 +108,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 3,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-09-23T22:51:19.407196Z",
+     "start_time": "2018-09-23T22:51:19.344847Z"
+    },
     "colab": {
      "autoexec": {
       "startup": false,
@@ -171,7 +183,7 @@
        "3  St John the Baptist Parish    LA"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -182,8 +194,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 4,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-09-23T22:51:20.069230Z",
+     "start_time": "2018-09-23T22:51:20.063958Z"
+    },
     "colab": {
      "autoexec": {
       "startup": false,
@@ -253,7 +269,7 @@
        "3  St. John the Baptist     43,044"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -315,8 +331,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
+   "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-09-23T22:51:32.874383Z",
+     "start_time": "2018-09-23T22:51:32.867469Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -324,14 +345,14 @@
        "'stjohnthebaptist'"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "john1 = state.loc[3, 'County']\n",
-    "john2 = population.loc[0, 'County']\n",
+    "john2 = population.loc[3, 'County']\n",
     "\n",
     "(john1\n",
     " .lower()\n",
@@ -353,8 +374,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
+   "execution_count": 9,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-09-23T22:51:33.478257Z",
+     "start_time": "2018-09-23T22:51:33.474293Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -362,13 +388,13 @@
        "'stjohnthebaptist'"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "(john1\n",
+    "(john2\n",
     " .lower()\n",
     " .strip()\n",
     " .replace(' parish', '')\n",
@@ -849,7 +875,7 @@
    "views": {}
   },
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -863,7 +889,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.5"
   },
   "toc": {
    "nav_menu": {},


### PR DESCRIPTION
Currently on [8.1/String Methods](http://www.textbook.ds100.org/ch/08/text_strings.html#String-Methods), the example intends to compare text cleaning for the sample dataframes `john1` and `john2`; however, the code examples are incorrect and clean `john1` twice. 